### PR TITLE
[fix] folder path를 (username, path) 대신 path만 전달 #46

### DIFF
--- a/src/main/kotlin/dev/codeswamp/core/article/application/usecase/query/read/byslug/GetPublishedArticleBySlugUseCaseImpl.kt
+++ b/src/main/kotlin/dev/codeswamp/core/article/application/usecase/query/read/byslug/GetPublishedArticleBySlugUseCaseImpl.kt
@@ -13,8 +13,14 @@ class GetPublishedArticleBySlugUseCaseImpl(
     private val publishedArticleRepository: PublishedArticleRepository,
 ): GetPublishedArticleBySlugUseCase {
     override fun handle(query: GetPublishedArticleBySlugQuery): ReadArticleResult {
-        val path = query.path.split("/")
+        println("path: ${query.path}")
+        val path = query.path.split("/").drop(2) // drop "", "/article"
         val slug = path.last()
+
+        for (folder in path)  {
+            println(folder)
+        }
+
 
         val folderId = folderPathResolver.findFolderByFullPath(path.dropLast(1))?.id
             ?: throw FolderPathNotFoundException(query.path)

--- a/src/main/kotlin/dev/codeswamp/core/article/domain/folder/repository/FolderRepository.kt
+++ b/src/main/kotlin/dev/codeswamp/core/article/domain/folder/repository/FolderRepository.kt
@@ -7,6 +7,6 @@ interface FolderRepository {
     fun delete(folder: Folder)
     fun findById(folderId: Long): Folder?
     fun findAllByIds(folderIds: List<Long>) : List<Folder>
-    fun findFolderByFullPath(rootName: String, paths: List<String>): Folder?
+    fun findFolderByFullPath(paths: List<String>): Folder?
     fun existsByParentIdAndName(parentId: Long, name: String): Boolean
 }

--- a/src/main/kotlin/dev/codeswamp/core/article/domain/folder/service/FolderPathResolver.kt
+++ b/src/main/kotlin/dev/codeswamp/core/article/domain/folder/service/FolderPathResolver.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 class FolderPathResolver(
     private val folderRepository: FolderRepository,
 ){
-    fun findFolderByFullPath(paths: List<String>): Folder? {
-        return folderRepository.findFolderByFullPath(paths[0], paths.drop(1))
+    fun findFolderByFullPath(path: List<String>): Folder? {
+        return folderRepository.findFolderByFullPath(path)
     }
 }

--- a/src/main/kotlin/dev/codeswamp/core/article/infrastructure/persistence/repositoryImpl/FolderRepositoryImpl.kt
+++ b/src/main/kotlin/dev/codeswamp/core/article/infrastructure/persistence/repositoryImpl/FolderRepositoryImpl.kt
@@ -43,8 +43,8 @@ class FolderRepositoryImpl(
         return folderJpaRepository.findAllById(folderIds).map { it.toDomain() }
     }
 
-    override fun findFolderByFullPath(rootName: String, paths: List<String>): Folder? {
-        val targetFolderId = folderNodeRepository.findFolderIdByFullPath(rootName, paths)
+    override fun findFolderByFullPath(path: List<String>): Folder? {
+        val targetFolderId = folderNodeRepository.findFolderIdByFullPath( path)
         return folderJpaRepository.findByIdOrNull(targetFolderId)?.toDomain()
     }
 


### PR DESCRIPTION
- 내부 parsing & drop에서의 버그를 수정
- "/articles/@username/...path/slug" 형태라 `.drop(2)`를 해야 함